### PR TITLE
feat: support JSON key string input

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Gradle - GCSBuildCache 
+# Gradle - GCSBuildCache
 
 This Gradle plugin provides a build cache implementation that uses Google Cloud Storage to store build artifacts.
 
@@ -6,19 +6,42 @@ This Gradle plugin provides a build cache implementation that uses Google Cloud 
 
 The build cache takes the following options:
 
-| Option             | Description                                                                                                      |
-|--------------------|------------------------------------------------------------------------------------------------------------------|
-| credentials        | JSON key file of the service account to use (optional) - leave blank to use Google Cloud SDK application default |
-| bucket             | Name of the Google Cloud Storage bucket (required)                                                               |
-| expireAfterSeconds | Amount of time to pass after which a cached artifact expires and is removed from the cache (optional)            |
+| Option                            | Description                                                                                           |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| bucket                            | Name of the Google Cloud Storage bucket (required)                                                    |
+| serviceAccountCredentialsFilePath | The path to the JSON key file of the service account to use (optional)                                |
+| serviceAccountCredentialsJSON     | The JSON key of the service account to use (optional)                                                 |
+| expireAfterSeconds                | Amount of time to pass after which a cached artifact expires and is removed from the cache (optional) |
+
+When both `serviceAccountCredentialsFilePath` and `serviceAccountCredentialsJSON` are not provided,
+this plugin defaults to the Google Cloud SDK default credentials.
+
+## Using Google Cloud SDK default credentials
+
+To use the Google Cloud SDK default credentials, you need to authenticate with the Google Cloud SDK.
+
+First, follow [the install guide](https://cloud.google.com/sdk/docs/install) to install the Google Cloud SDK.
+
+Next, run the following command in a terminal:
+
+```bash
+gcloud init
+```
+
+When prompted, choose the project ID where you created your GCS bucket.
+
+Finally, run the following command in a terminal:
+
+```
+gcloud auth application-default login
+```
+
+Now you're ready to use the Gradle remote build cache.
 
 ## Usage
 
-There are multiple ways to use the Google Cloud Storage based build cache inside your projects.
+Add this plugin to your `settings.gradle.kts` as follows:
 
-### As plugin in `settings.gradle.kts`
-
-.settings.gradle.kts
 ```kotlin
 plugins {
     id("com.ridedott.gradle-gcs-build-cache") version "1.0.1"
@@ -26,13 +49,10 @@ plugins {
 
 buildCache {
     remote<com.ridedott.gradle.buildcache.GCSBuildCache> {
-        credentials = 'my-key.json' // optional - leave blank to use Google Cloud SDK default
-        bucket = "my-bucket-name"
+        bucket = "my-bucket-name" // required
+        serviceAccountCredentialsFilePath = 'my-key.json' // optional
+        serviceAccountCredentialsJSON = "{ ... }" // optional
         expireAfterSeconds = 60 * 60 * 24 // optional
     }
 }
 ```
-
-## License
-
-include::LICENSE[]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 }
 
 group = "com.ridedott"
-version = "1.0.0"
+version = "1.0.1"
 
 repositories {
     google()

--- a/src/main/kotlin/com/ridedott/gradle/buildcache/GCSBuildCache.kt
+++ b/src/main/kotlin/com/ridedott/gradle/buildcache/GCSBuildCache.kt
@@ -26,6 +26,7 @@ import org.gradle.caching.configuration.AbstractBuildCache
  */
 abstract class GCSBuildCache(
     var bucket: String = "",
-    var credentials: String = "",
+    var serviceAccountCredentialsFilePath: String = "",
+    var serviceAccountCredentialsJSON: String = "",
     var expireAfterSeconds: Long = 0L
 ) : AbstractBuildCache()

--- a/src/main/kotlin/com/ridedott/gradle/buildcache/GCSBuildCacheServiceFactory.kt
+++ b/src/main/kotlin/com/ridedott/gradle/buildcache/GCSBuildCacheServiceFactory.kt
@@ -34,10 +34,10 @@ class GCSBuildCacheServiceFactory : BuildCacheServiceFactory<GCSBuildCache> {
         val bucket = configuration.bucket.takeIf { it.isNotEmpty() }
             ?: throw GradleException("Bucket name was not defined. Check GitHub for instructions.")
 
-        val credentialsDescription = if (configuration.credentials.isEmpty()) {
-            "application default"
-        } else {
-            "from file: ${configuration.credentials}"
+        val credentialsDescription = when {
+            configuration.serviceAccountCredentialsJSON.isNotEmpty() -> "from JSON"
+            configuration.serviceAccountCredentialsFilePath.isNotEmpty() -> "from file: ${configuration.serviceAccountCredentialsFilePath}"
+            else -> "application default"
         }
 
         val expireAfterSeconds = configuration.expireAfterSeconds
@@ -48,6 +48,11 @@ class GCSBuildCacheServiceFactory : BuildCacheServiceFactory<GCSBuildCache> {
             .config("bucket", bucket)
             .config("expireAfterSeconds", expireAfterSeconds.toString())
 
-        return GCSBuildCacheService(configuration.credentials, bucket, expireAfterSeconds)
+        return GCSBuildCacheService(
+            bucket,
+            expireAfterSeconds,
+            configuration.serviceAccountCredentialsFilePath,
+            configuration.serviceAccountCredentialsJSON,
+        )
     }
 }


### PR DESCRIPTION
This PR adds support for setting a service account JSON key from the plugin configuration in your application's `settings.gradle.kts`. This can be useful for example when your build server has this key injected into its environment variables during CI workflow execution.

Example usage:

```
buildCache {
    remote<com.ridedott.gradle.buildcache.GCSBuildCache> {
        bucket = "rider-android-gradle-build-cache"
        expireAfterSeconds = 60 * 60 * 24
        serviceAccountCredentialsJSON = System.getenv("MY_TOKEN")
    }
}
```

The example above would use JSON if provided in the `MY_TOKEN` environment variable. If not, it would default to the Google Cloud SDK's application default. See the README for more information.