### PR TITLE
Cleaner way of controlling outgoingVariants

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,11 +50,11 @@ tasks.withType<KotlinCompile>().configureEach {
     }
 }
 
-// Workaround for runtime variants as discussed:
-// https://youtrack.jetbrains.com/issue/KT-45335
-configurations["runtimeElements"].attributes {
-    attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 8)
-}
-configurations["apiElements"].attributes {
-    attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 8)
+// Even though jvmTarget is specified above, that only controls the version of bytecode produced
+// Configuring all Java Compile tasks to 1.8 controls the outgoingVariants
+// Using Java toolchains is the easiest way to change all Java Compile tasks to 1.8
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(8))
+    }
 }


### PR DESCRIPTION
PR #9 was a bit of a hack. I have since researched the better, more supported way of controlling Gradle variants.

The Gradle variants are produced by the Java Compile tasks, which also need to be set to `1.8`. The easiest way to do this is with java toolchains.

You can run `./gradlew outgoingVariants` to see that this produces the same results as the previous hack.